### PR TITLE
Fix case when no update is available

### DIFF
--- a/index.php
+++ b/index.php
@@ -88,10 +88,10 @@ class Updater {
 	public function checkForUpdate() {
 		$response = $this->getUpdateServerResponse();
 
-		$version = $response['version'];
-		$versionString = $response['versionstring'];
+		$version = isset($response['version']) ? $response['version'] : '';
+		$versionString = isset($response['versionstring']) ? $response['versionstring'] : '';
 
-		if ($version !== $this->currentVersion) {
+		if ($version !== '' && $version !== $this->currentVersion) {
 			$this->updateAvailable = true;
 			$updateText = 'Update to ' . $versionString . ' available.';
 		} else {
@@ -333,6 +333,11 @@ class Updater {
 			throw new \Exception('Could not do request to updater server: '.curl_error($curl));
 		}
 		curl_close($curl);
+
+		// Response can be empty when no update is available
+		if($response === '') {
+			return [];
+		}
 
 		$xml = simplexml_load_string($response);
 		if($xml === false) {


### PR DESCRIPTION
The updater server returns an empty string in case no update is available.

Before:
![2016-06-25_12-26-17](https://cloud.githubusercontent.com/assets/878997/16356193/19185f4a-3ad0-11e6-88bc-ed2f998364f3.png)

After:
![2016-06-25_12-26-14](https://cloud.githubusercontent.com/assets/878997/16356194/1bbdce4c-3ad0-11e6-8fce-70c4ded6c79e.png)
