### PR TITLE
Remove CURLOPT_FOLLOWLOCATION

### DIFF
--- a/index.php
+++ b/index.php
@@ -541,7 +541,6 @@ class Updater {
 		$fp = fopen($storageLocation . basename($response['url']), 'w+');
 		$ch = curl_init($response['url']);
 		curl_setopt($ch, CURLOPT_FILE, $fp);
-		curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
 		if(curl_exec($ch) === false) {
 			throw new \Exception('Curl error: ' . curl_error($ch));
 		}


### PR DESCRIPTION
CURLOPT_FOLLOWLOCATION isn't working when PHP with open_basedir is used

Fixes https://github.com/nextcloud/updater/issues/25

cc @MorrisJobke 