### PR TITLE
Fix open_basedir violation in ./oc/updater/../../

### DIFF
--- a/index.php
+++ b/index.php
@@ -42,7 +42,7 @@ class RecursiveDirectoryIteratorWithoutData extends \RecursiveFilterIterator {
 			'data',
 			'..',
 		];
-		return !($this->isDir() && in_array($this->getFilename(), $excludes, true));
+		return !(in_array($this->getFilename(), $excludes, true) || $this->isDir());
 	}
 }
 

--- a/lib/RecursiveDirectoryIteratorWithoutData.php
+++ b/lib/RecursiveDirectoryIteratorWithoutData.php
@@ -29,6 +29,6 @@ class RecursiveDirectoryIteratorWithoutData extends \RecursiveFilterIterator {
 			'data',
 			'..',
 		];
-		return !($this->isDir() && in_array($this->getFilename(), $excludes, true));
+		return !(in_array($this->getFilename(), $excludes, true) || $this->isDir());
 	}
 }


### PR DESCRIPTION
Don't call `SplFileInfo::isDir()` when the directory is excluded anyway.

Fixes #62