### PR TITLE
Ignore custom app folders

### DIFF
--- a/index.php
+++ b/index.php
@@ -289,7 +289,7 @@ class Updater {
 	 * @return array
 	 */
 	private function getExpectedElementsList() {
-		return [
+		$expected = [
 			// Generic
 			'.',
 			'..',
@@ -327,6 +327,26 @@ class Updater {
 			'occ',
 			'db_structure.xml',
 		];
+		return array_merge($expected, $this->getAppDirectories());
+	}
+
+	/**
+	 * Returns app directories specified in config.php
+	 *
+	 * @return array
+	 */
+	private function getAppDirectories() {
+		$expected = [];
+		if($appsPaths = $this->getConfigOption('apps_paths')) {
+			foreach ($appsPaths as $appsPath) {
+				$parentDir = realpath($this->baseDir . '/../');
+				$appDir = basename($appsPath['path']);
+				if(strpos($appsPath['path'], $parentDir) === 0 && $appDir !== 'apps') {
+					$expected[] = $appDir;
+				}
+			}
+		}
+		return $expected;
 	}
 
 	/**
@@ -873,6 +893,7 @@ EOF;
 			'apps',
 			'updater',
 		];
+		$excludedElements = array_merge($excludedElements, $this->getAppDirectories());
 		/**
 		 * @var string $path
 		 * @var \SplFileInfo $fileInfo

--- a/lib/Updater.php
+++ b/lib/Updater.php
@@ -174,7 +174,7 @@ class Updater {
 	 * @return array
 	 */
 	private function getExpectedElementsList() {
-		return [
+		$expected = [
 			// Generic
 			'.',
 			'..',
@@ -212,6 +212,26 @@ class Updater {
 			'occ',
 			'db_structure.xml',
 		];
+		return array_merge($expected, $this->getAppDirectories());
+	}
+
+	/**
+	 * Returns app directories specified in config.php
+	 *
+	 * @return array
+	 */
+	private function getAppDirectories() {
+		$expected = [];
+		if($appsPaths = $this->getConfigOption('apps_paths')) {
+			foreach ($appsPaths as $appsPath) {
+				$parentDir = realpath($this->baseDir . '/../');
+				$appDir = basename($appsPath['path']);
+				if(strpos($appsPath['path'], $parentDir) === 0 && $appDir !== 'apps') {
+					$expected[] = $appDir;
+				}
+			}
+		}
+		return $expected;
 	}
 
 	/**
@@ -758,6 +778,7 @@ EOF;
 			'apps',
 			'updater',
 		];
+		$excludedElements = array_merge($excludedElements, $this->getAppDirectories());
 		/**
 		 * @var string $path
 		 * @var \SplFileInfo $fileInfo

--- a/tests/features/bootstrap/FeatureContext.php
+++ b/tests/features/bootstrap/FeatureContext.php
@@ -423,4 +423,38 @@ jFSE6+KKI+HAE132eaXY5A==',
 		$content = preg_replace("!'version'\s*=>\s*'(\d+\.\d+\.\d+)\.\d+!", "'version' => '$1", $content);
 		file_put_contents($configFile, $content);
 	}
+
+	/**
+	 * @Given there is a folder called :name
+	 */
+	public function thereIsAFolderCalled($name)
+	{
+		mkdir($this->serverDir . 'nextcloud/' . $name);
+	}
+
+	/**
+	 * @Given there is a config for a secondary apps directory called :name
+	 */
+	public function thereIsAConfigForASecondaryAppsDirectoryCalled($name)
+	{
+		$configFile = $this->serverDir . 'nextcloud/config/config.php';
+		$content = file_get_contents($configFile);
+		$appsPaths = <<<EOF
+	'apps_paths' => [
+		[
+			'path'=> dirname(__DIR__) . '/apps',
+			'url' => '/apps',
+			'writable' => true,
+		],
+		[
+			'path'=> dirname(__DIR__) . '/%s',
+			'url' => '/%s',
+			'writable' => true,
+		],
+	],
+EOF;
+		$appsPaths = sprintf($appsPaths, $name, $name);
+		$content = preg_replace("!\);!", $appsPaths . ');', $content);
+		file_put_contents($configFile, $content);
+	}
 }

--- a/tests/features/cli.feature
+++ b/tests/features/cli.feature
@@ -69,3 +69,25 @@ Feature: CLI updater
     Then the installed version should be 10.0.0
     And maintenance mode should be off
     And upgrade is not required
+
+  Scenario: Update is available and apps2 folder is there and configured - 10.0.0 to 10.0.1
+    Given the current installed version is 10.0.0
+    And there is an update to version 10.0.1 available
+    And there is a folder called "apps2"
+    And there is a config for a secondary apps directory called "apps2"
+    When the CLI updater is run successfully
+    Then the installed version should be 10.0.1
+    And maintenance mode should be off
+    And upgrade is not required
+
+  Scenario: Update is available and apps2 folder is there and not configured - 10.0.0 to 10.0.1
+    Given the current installed version is 10.0.0
+    And there is an update to version 10.0.1 available
+    And there is a folder called "apps2"
+    When the CLI updater is run
+    Then the return code should not be 0
+    And the output should contain "The following extra files have been found"
+    And the output should contain "apps2"
+    And the installed version should be 10.0.0
+    And maintenance mode should be off
+    And upgrade is not required


### PR DESCRIPTION
This PR adds custom app folders that are within the nextcloud root to the expected files list and ignores them when deleting.

Fix for https://github.com/nextcloud/updater/issues/40