### PR TITLE
Refactor recursiveDelete

### DIFF
--- a/index.php
+++ b/index.php
@@ -787,10 +787,23 @@ EOF;
 			\RecursiveIteratorIterator::CHILD_FIRST
 		);
 
+		$directories = array();
+		$files = array();
 		foreach ($iterator as $fileInfo) {
-			$action = $fileInfo->isDir() ? 'rmdir' : 'unlink';
-			$action($fileInfo->getRealPath());
+			if ($fileInfo->isDir()) {
+				$directories[] = $fileInfo->getRealPath();
+			} else {
+				$files[] = $fileInfo->getRealPath();
+			}
 		}
+		
+		foreach ($files as $file) {
+			unlink($file);
+		}
+		foreach ($directories as $dir) {
+			rmdir($dir);	
+		}
+		
 		$state = rmdir($folder);
 		if($state === false) {
 			throw new \Exception('Could not rmdir ' . $folder);

--- a/index.php
+++ b/index.php
@@ -796,7 +796,6 @@ EOF;
 				$files[] = $fileInfo->getRealPath();
 			}
 		}
-		
 		foreach ($files as $file) {
 			unlink($file);
 		}

--- a/lib/Updater.php
+++ b/lib/Updater.php
@@ -671,7 +671,6 @@ EOF;
 			new \RecursiveDirectoryIterator($folder, \RecursiveDirectoryIterator::SKIP_DOTS),
 			\RecursiveIteratorIterator::CHILD_FIRST
 		);
-		
 		$directories = array();
 		$files = array();
 		foreach ($iterator as $fileInfo) {

--- a/lib/Updater.php
+++ b/lib/Updater.php
@@ -681,7 +681,6 @@ EOF;
 				$files[] = $fileInfo->getRealPath();
 			}
 		}
-		
 		foreach ($files as $file) {
 			unlink($file);
 		}

--- a/lib/Updater.php
+++ b/lib/Updater.php
@@ -671,11 +671,24 @@ EOF;
 			new \RecursiveDirectoryIterator($folder, \RecursiveDirectoryIterator::SKIP_DOTS),
 			\RecursiveIteratorIterator::CHILD_FIRST
 		);
-
+		
+		$directories = array();
+		$files = array();
 		foreach ($iterator as $fileInfo) {
-			$action = $fileInfo->isDir() ? 'rmdir' : 'unlink';
-			$action($fileInfo->getRealPath());
+			if ($fileInfo->isDir()) {
+				$directories[] = $fileInfo->getRealPath();
+			} else {
+				$files[] = $fileInfo->getRealPath();
+			}
 		}
+		
+		foreach ($files as $file) {
+			unlink($file);
+		}
+		foreach ($directories as $dir) {
+			rmdir($dir);	
+		}
+		
 		$state = rmdir($folder);
 		if($state === false) {
 			throw new \Exception('Could not rmdir ' . $folder);

--- a/lib/Updater.php
+++ b/lib/Updater.php
@@ -671,6 +671,7 @@ EOF;
 			new \RecursiveDirectoryIterator($folder, \RecursiveDirectoryIterator::SKIP_DOTS),
 			\RecursiveIteratorIterator::CHILD_FIRST
 		);
+
 		$directories = array();
 		$files = array();
 		foreach ($iterator as $fileInfo) {


### PR DESCRIPTION
The recursiveDelete method causes problems in certain environments with the RecursiveDirectoryIterator not iterating through all elements of a tree when deleting nodes while iterating. See nextcloud/server#2737 for a more detailed discussion of the issue.

This is solved by first completing the iteration and only then deleting all elements (first the files, then the directories).