### PR TITLE
Add .well-known dir to expected dir list for RFC5785 compliancy

### DIFF
--- a/index.php
+++ b/index.php
@@ -294,6 +294,7 @@ class Updater {
 			'.',
 			'..',
 			// Folders
+			'.well-known',
 			'3rdparty',
 			'apps',
 			'config',


### PR DESCRIPTION
The .well-known directory has been added to expected list in updater. This makes Nextcloud compliant with RFC 5785 which establishes a .well-known URI location. ( cf. https://tools.ietf.org/html/rfc5785 )
Known to be used by Let's Encrypt
