### PR TITLE
Explicitly check if extracting files was successful

### DIFF
--- a/index.php
+++ b/index.php
@@ -757,14 +757,17 @@ EOF;
 		$zip = new \ZipArchive;
 		$zipState = $zip->open($downloadedFilePath);
 		if ($zipState === true) {
-			$zip->extractTo(dirname($downloadedFilePath));
+			$extraction = $zip->extractTo(dirname($downloadedFilePath));
+			if($extraction === false) {
+				throw new \Exception('Error during unpacking zipfile: '.($zip->getStatusString()));
+			}
 			$zip->close();
 			$state = unlink($downloadedFilePath);
 			if($state === false) {
-				throw new \Exception('Cant unlink '. $downloadedFilePath);
+				throw new \Exception('Can\'t unlink '. $downloadedFilePath);
 			}
 		} else {
-			throw new \Exception('Cant handle ZIP file. Error code is: '.$zipState);
+			throw new \Exception('Can\'t handle ZIP file. Error code is: '.$zipState);
 		}
 
 		// Ensure that the downloaded version is not lower


### PR DESCRIPTION
The updater does not check if the downloaded file could be extracted successfully.
This is bad in case that not enough space is available or quota limits have been reached.

This patch checks explicitly for possible extraction errors and throws an exception in such cases.

(Fixing two typos as well)