### PR TITLE
Handle symlinks in updater correctly

### DIFF
--- a/index.php
+++ b/index.php
@@ -838,7 +838,11 @@ EOF;
 			if ($fileInfo->isDir()) {
 				$directories[] = $fileInfo->getRealPath();
 			} else {
-				$files[] = $fileInfo->getRealPath();
+                if ($fileInfo->isLink()) {
+                    $files[] = $fileInfo->getPathName();
+                } else {
+                    $files[] = $fileInfo->getRealPath();
+                }
 			}
 		}
 		
@@ -929,7 +933,7 @@ EOF;
 					continue;
 				}
 			}
-			if($fileInfo->isFile()) {
+            if($fileInfo->isFile() || $fileInfo->isLink()) {
 				$state = unlink($path);
 				if($state === false) {
 					throw new \Exception('Could not unlink: '.$path);

--- a/index.php
+++ b/index.php
@@ -838,11 +838,11 @@ EOF;
 			if ($fileInfo->isDir()) {
 				$directories[] = $fileInfo->getRealPath();
 			} else {
-                if ($fileInfo->isLink()) {
-                    $files[] = $fileInfo->getPathName();
-                } else {
-                    $files[] = $fileInfo->getRealPath();
-                }
+				if ($fileInfo->isLink()) {
+					$files[] = $fileInfo->getPathName();
+				} else {
+					$files[] = $fileInfo->getRealPath();
+				}
 			}
 		}
 		
@@ -933,7 +933,7 @@ EOF;
 					continue;
 				}
 			}
-            if($fileInfo->isFile() || $fileInfo->isLink()) {
+			if($fileInfo->isFile() || $fileInfo->isLink()) {
 				$state = unlink($path);
 				if($state === false) {
 					throw new \Exception('Could not unlink: '.$path);

--- a/lib/Updater.php
+++ b/lib/Updater.php
@@ -723,7 +723,11 @@ EOF;
 			if ($fileInfo->isDir()) {
 				$directories[] = $fileInfo->getRealPath();
 			} else {
-				$files[] = $fileInfo->getRealPath();
+                if ($fileInfo->isLink()) {
+                    $files[] = $fileInfo->getPathName();
+                } else {
+                    $files[] = $fileInfo->getRealPath();
+                }			 
 			}
 		}
 		
@@ -814,7 +818,7 @@ EOF;
 					continue;
 				}
 			}
-			if($fileInfo->isFile()) {
+            if($fileInfo->isFile() || $fileInfo->isLink()) {
 				$state = unlink($path);
 				if($state === false) {
 					throw new \Exception('Could not unlink: '.$path);

--- a/lib/Updater.php
+++ b/lib/Updater.php
@@ -723,11 +723,11 @@ EOF;
 			if ($fileInfo->isDir()) {
 				$directories[] = $fileInfo->getRealPath();
 			} else {
-                if ($fileInfo->isLink()) {
-                    $files[] = $fileInfo->getPathName();
-                } else {
-                    $files[] = $fileInfo->getRealPath();
-                }
+				if ($fileInfo->isLink()) {
+					$files[] = $fileInfo->getPathName();
+				} else {
+					$files[] = $fileInfo->getRealPath();
+				}
 			}
 		}
 		
@@ -818,7 +818,7 @@ EOF;
 					continue;
 				}
 			}
-            if($fileInfo->isFile() || $fileInfo->isLink()) {
+			if($fileInfo->isFile() || $fileInfo->isLink()) {
 				$state = unlink($path);
 				if($state === false) {
 					throw new \Exception('Could not unlink: '.$path);

--- a/lib/Updater.php
+++ b/lib/Updater.php
@@ -727,7 +727,7 @@ EOF;
                     $files[] = $fileInfo->getPathName();
                 } else {
                     $files[] = $fileInfo->getRealPath();
-                }			 
+                }
 			}
 		}
 		


### PR DESCRIPTION
Same request as in #165. Unfortunatley I was not able to interactively rebase my branch because of my poor git knowledge. This is why I had to reset my fork and applied the changes again. Sorry for confusing you...

Steps to reproduce:
Use Open SUSE Tumbleweed and install nextcloud via
sudo zypper in nextcloud
Point your browser to your nextcloud installation and select update channel daily. Reload the page and try to update your instance with the web based updater.
The update process will fail due to files which couldn't be removed beforehand by the updater itself. The files which cause this problem are symlinks that are generated at the installation because of
https://build.opensuse.org/package/view_file/openSUSE:Factory/nextcloud/nextcloud.spec?expand=1
Line 164: %fdupes -s $RPM_BUILD_ROOT/%{apache_serverroot}/%{name}
The problem is solved on my machine if we check for symlinks, files and folders in the delete functions.