### PR TITLE
Add .well-known as expected folder but exclude from backup/delete.

### DIFF
--- a/index.php
+++ b/index.php
@@ -39,6 +39,7 @@ class RecursiveDirectoryIteratorWithoutData extends \RecursiveFilterIterator {
 	public function accept() {
 		/** @var \DirectoryIterator $this */
 		$excludes = [
+			'.well-known',
 			'data',
 			'..',
 		];
@@ -294,6 +295,7 @@ class Updater {
 			'.',
 			'..',
 			// Folders
+			'.well-known',
 			'3rdparty',
 			'apps',
 			'config',
@@ -452,6 +454,7 @@ class Updater {
 		$this->silentLog('[info] createBackup()');
 
 		$excludedElements = [
+			'.well-known',
 			'data',
 		];
 
@@ -918,6 +921,7 @@ EOF;
 
 		// Delete the rest
 		$excludedElements = [
+			'.well-known',
 			'data',
 			'index.php',
 			'status.php',

--- a/lib/RecursiveDirectoryIteratorWithoutData.php
+++ b/lib/RecursiveDirectoryIteratorWithoutData.php
@@ -26,6 +26,7 @@ class RecursiveDirectoryIteratorWithoutData extends \RecursiveFilterIterator {
 	public function accept() {
 		/** @var \DirectoryIterator $this */
 		$excludes = [
+			'.well-known',
 			'data',
 			'..',
 		];

--- a/lib/Updater.php
+++ b/lib/Updater.php
@@ -179,6 +179,7 @@ class Updater {
 			'.',
 			'..',
 			// Folders
+			'.well-known',
 			'3rdparty',
 			'apps',
 			'config',
@@ -337,6 +338,7 @@ class Updater {
 		$this->silentLog('[info] createBackup()');
 
 		$excludedElements = [
+			'.well-known',
 			'data',
 		];
 
@@ -803,6 +805,7 @@ EOF;
 
 		// Delete the rest
 		$excludedElements = [
+			'.well-known',
 			'data',
 			'index.php',
 			'status.php',

--- a/tests/features/stable13.feature
+++ b/tests/features/stable13.feature
@@ -28,6 +28,27 @@ Feature: CLI updater - stable13 base
     And maintenance mode should be off
     And upgrade is not required
 
+  Scenario: Update is available but unexpected folder found - 13.0.3 to 13.0.4
+    Given the current installed version is 13.0.3
+    And there is an update to version 13.0.4 available
+    And there is a folder called "test123"
+    When the CLI updater is run
+    Then the return code should not be 0
+    And the output should contain "The following extra files have been found"
+    Then the installed version should be 13.0.3
+    And maintenance mode should be off
+    And upgrade is not required
+
+  Scenario: Update is available and .well-known folder exist - 13.0.3 to 13.0.4
+    Given the current installed version is 13.0.3
+    And there is an update to version 13.0.4 available
+    And there is a folder called ".well-known"
+    When the CLI updater is run successfully
+    And the output should contain "Update successful"
+    Then the installed version should be 13.0.4
+    And maintenance mode should be off
+    And upgrade is not required
+
   Scenario: Update is available - 13.0.1 to 14.0.3
     Given the current installed version is 13.0.1
     And PHP is at least in version 7.0


### PR DESCRIPTION
Improved version of https://github.com/nextcloud/updater/pull/152

Allows to update nextcloud even when there is a folder .well-known. Folder is excluded from backup and delete routine. 

