### PR TITLE
Fix setting of maintenance mode from within PHP in CLI mode

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -124,13 +124,6 @@ pipeline:
     when:
       matrix:
         TESTS: php72-stable14
-  php70-master:
-    image: nextcloudci/php7.0:php7.0-19
-    commands:
-      - make test-master
-    when:
-      matrix:
-        TESTS: php70-master
   php71-master:
     image: nextcloudci/php7.1:php7.1-16
     commands:
@@ -160,7 +153,6 @@ matrix:
     - TESTS: php70-stable14
     - TESTS: php71-stable14
     - TESTS: php72-stable14
-    - TESTS: php70-master
     - TESTS: php71-master
     - TESTS: php72-master
     - TESTS: signed-off-check

--- a/.drone.yml
+++ b/.drone.yml
@@ -4,21 +4,6 @@ clone:
     depth: 1
 
 pipeline:
-  signed-off-check:
-    image: nextcloudci/php7.0:php7.0-19
-    environment:
-      - APP_NAME=updater
-      - CORE_BRANCH=master
-      - DB=sqlite
-    commands:
-      - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
-      - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DB
-      - cd ../server
-      - php ./build/signed-off-checker.php
-    secrets: [ github_token ]
-    when:
-      matrix:
-        TESTS: signed-off-check
   check-same-code-base:
     image: nextcloudci/php7.0:php7.0-19
     commands:
@@ -155,7 +140,6 @@ matrix:
     - TESTS: php72-stable14
     - TESTS: php71-master
     - TESTS: php72-master
-    - TESTS: signed-off-check
     - TESTS: check-same-code-base
 
 branches: [ master, stable* ]

--- a/lib/UpdateCommand.php
+++ b/lib/UpdateCommand.php
@@ -311,8 +311,8 @@ class UpdateCommand extends Command {
 			}
 
 			try {
-				$this->updater->setMaintenanceMode(false);
-				$this->updater->log('[info] maintenance mode is disabled');
+				system('./occ maintenance:mode --off', $returnValueMaintenanceMode);
+				$this->updater->log('[info] maintenance mode is disabled - return code: ' . $returnValueMaintenanceMode);
 				$output->writeln('');
 				$output->writeln('Maintenance mode is disabled');
 			} catch (\Exception $e) {

--- a/tests/features/cli.feature
+++ b/tests/features/cli.feature
@@ -28,8 +28,7 @@ Feature: CLI updater
     Then the return code should not be 0
     And the output should contain "Download failed - Not Found (HTTP 404)"
     And the installed version should be 12.0.0
-    # known issue - TODO - it should be:
-    #And maintenance mode should be off
+    And maintenance mode should be off
     And upgrade is not required
 
   Scenario: Update without valid signature is being offered - 11.0.0 to 11.0.1
@@ -40,8 +39,7 @@ Feature: CLI updater
     Then the return code should not be 0
     And the output should contain "Signature of update is not valid"
     And the installed version should be 11.0.0
-    # known issue - TODO - it should be:
-    #And maintenance mode should be off
+    And maintenance mode should be off
     And upgrade is not required
 
   Scenario: Update to older version - 12.0.0 to 11.0.2
@@ -51,8 +49,7 @@ Feature: CLI updater
     Then the return code should not be 0
     And the output should contain "Downloaded version is lower than installed version"
     And the installed version should be 12.0.0
-    # known issue - TODO - it should be:
-    #And maintenance mode should be off
+    And maintenance mode should be off
     And upgrade is not required
 
   Scenario: Update is available but autoupdate is disabled - 12.0.0 to 12.0.1


### PR DESCRIPTION
* fixes #210

Background:

The `setMaintenanceMode` does `require('config.php');` and thus is loading the config.php into the CLI context, changing the maintenance mode value and then writing the file back. This works fine in the web based UI because there each step (disabling the maintenance mode is a single step) is executed in one request. On the CLI side we do all steps within one single PHP call. That results in following execution:

* fetching new code
* replacing code
* enable maintenance mode
* upgrade
* disable maintenance mode

This sounds not like a problem, but there is one in the disable step. The "upgrade" step updates the config.php outside of the currently running PHP process, but the "disable maintenance mode" just uses the same config.php as when the CLI process was started. That means that it still had the old version number and thus was writing it back after the upgrade happened. This triggers the described misbehavior in #210.

This is only triggered sometimes because we use OPCache to cache PHP files, which is checked once a second for updates, but if between the end of "upgrade" and beginning of "disable maintenance mode" this is not checked it loads the old file content. That's the reason why also some tests fail from time to time in a weird way.
