### PR TITLE
Add a configuration option to skip the integrity verification

### DIFF
--- a/lib/Updater.php
+++ b/lib/Updater.php
@@ -596,6 +596,13 @@ class Updater {
 			return;
 		}
 
+		if ($this->getConfigOption('updater.skipIntegrityVerification')) {
+			// openssl_verify() may fail on systems with very low PHP memory (e.g. 64MB).
+			// For this case, the integrity check may be skipped
+			$this->silentLog('[notice] The integrity verification has been explicitly skipped.');
+			return;
+		}
+
 		$response = $this->getUpdateServerResponse();
 		if(!isset($response['signature'])) {
 			throw new \Exception('No signature specified for defined update');


### PR DESCRIPTION
On systems with very low PHP memory (e.g. 64MB), the PHP function
openssl_verify may fail as it checks the complete nextcloud zip file
in RAM which is not possible with only 64 MB.
For this, an option has been introduced that allows to skip the
integrity verification.
Note: This option should only be used for systems that have issues
in running the updater.