### PR TITLE
Execute occ with same php version as updater

### DIFF
--- a/lib/UpdateCommand.php
+++ b/lib/UpdateCommand.php
@@ -292,7 +292,7 @@ class UpdateCommand extends Command {
 
 			chdir($path . '/..');
 			chmod('occ', 0755); # TODO do this in the updater
-			system('./occ upgrade -v', $returnValue);
+			system(PHP_BINARY . ' ./occ upgrade -v', $returnValue);
 
 			$output->writeln('');
 			if ($input->isInteractive()) {
@@ -311,7 +311,7 @@ class UpdateCommand extends Command {
 			}
 
 			try {
-				system('./occ maintenance:mode --off', $returnValueMaintenanceMode);
+				system(PHP_BINARY . ' ./occ maintenance:mode --off', $returnValueMaintenanceMode);
 				$this->updater->log('[info] maintenance mode is disabled - return code: ' . $returnValueMaintenanceMode);
 				$output->writeln('');
 				$output->writeln('Maintenance mode is disabled');


### PR DESCRIPTION
Fix #261 

1) Have multiple php version installed.
2) Call updater.phar with a non default php binary.
3) See that occ is not called with the same php binary.

This patch will use `PHP_BINARY` for executing occ.