### PR TITLE
implement getUpdaterUrl to handle reverse proxy configurations

### DIFF
--- a/lib/Updater.php
+++ b/lib/Updater.php
@@ -431,6 +431,37 @@ class Updater {
 	}
 
 	/**
+	 * Gets the updater URL for this nextcloud instance
+	 * Supports reverse proxy configurations (overwrite*)
+	 * @return string
+	 */
+	public function getUpdaterUrl() {
+		$this->silentLog('[info] getUpdaterUrl()');
+
+		// Start from the request URI of the server, and get our updater sub-path
+		// from the URI, typically this is "/updater/"
+		$updaterUrl = explode('?', $_SERVER['REQUEST_URI'], 2)[0];
+		$this->silentLog('[debug] getUpdaterUrl() initial from _SERVER array: ' . $updaterUrl);
+
+		// Ensure updater URL is suffixed with /index.php
+		if(strpos($updaterUrl, 'index.php') === false) {
+			$updaterUrl = rtrim($updaterUrl, '/') . '/index.php';
+		}
+		$this->silentLog('[debug] getUpdaterUrl() after trimming and index.php suffix: ' . $updaterUrl);
+
+		// Support reverse proxy configuration
+		// https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/reverse_proxy_configuration.html#overwrite-parameters
+		$overwriteWebRootConfig = $this -> getConfigOption('overwritewebroot');
+		if(!empty($overwriteWebRootConfig)) {
+			$this->silentLog('[info] getUpdaterUrl() detected overwrite web root configuration >' . $overwriteWebRootConfig . '<, updating for reverse proxy');
+			$updaterUrl = $overwriteWebRootConfig . $updaterUrl;
+		}
+		$this->silentLog('[info] getUpdaterUrl() final: ' . $updaterUrl);
+
+		return $updaterUrl;
+	}
+
+	/**
 	 * @return array
 	 * @throws \Exception
 	 */


### PR DESCRIPTION
As per #265  - https://github.com/nextcloud/updater/issues/265#issuecomment-571642061 @kesselb suggestion

These changes
1.  remove `updaterUrl` logic (which was previously set in MAIN BODY) in a new function entitled: `getUpdaterUrl()` with the updater class
2. add support for adjusting the `updaterUrl` from `getConfigOption('overwritewebroot')`
3. add `[info]` and `[debug]` logging here where appropriate/helpful

Test Results:
1. Logs:
```
tail -f /opt/nextcloud/updater.log

2020-11-16T20:00:01-0500 Fzl86ny556 [info] getUpdaterUrl()
2020-11-16T20:00:01-0500 Fzl86ny556 [debug] getUpdaterUrl() initial from _SERVER array: /updater/
2020-11-16T20:00:01-0500 Fzl86ny556 [debug] getUpdaterUrl() after trimming and index.php suffix: /updater/index.php
2020-11-16T20:00:01-0500 Fzl86ny556 [info] getUpdaterUrl() detected overwrite web root configuration >/cloud<, updating for reverse proxy
2020-11-16T20:00:01-0500 Fzl86ny556 [info] getUpdaterUrl() final: /cloud/updater/index.php
```
2. verified locally that this version of `index.php` (from my branch) correctly handles the updater links (which I had previously manually verified in https://github.com/nextcloud/updater/issues/265#issuecomment-727231185
> `updater-endpoint` == value="/cloud/updater/index.php"
> go back button == `href=/cloud/updater/../`