### PR TITLE
Remove obsolete pipeline php72-master

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -233,24 +233,6 @@ trigger:
 
 ---
 kind: pipeline
-name: php72-master
-
-steps:
-  - name: php72-master
-    image: nextcloudci/php7.2:php7.2-12
-    commands:
-      - make test-master
-
-trigger:
-  branch:
-    - master
-    - stable*
-  event:
-    - pull_request
-    - push
-
----
-kind: pipeline
 name: php73-master
 
 steps:

--- a/tests/features/master.feature
+++ b/tests/features/master.feature
@@ -7,6 +7,6 @@ Feature: CLI updater - master base
     And the version number is decreased in the config.php to enforce upgrade
     When the CLI updater is run successfully
     And the output should contain "Update successful"
-    Then the installed version should be 20.0
+    Then the installed version should be 22.0
     And maintenance mode should be off
     And upgrade is not required


### PR DESCRIPTION
Master (which is Nextcloud 22) doesn't support PHP 7.2 any more.

For https://github.com/nextcloud/updater/issues/332