### PR TITLE
Allow custom logfile location

### DIFF
--- a/lib/Updater.php
+++ b/lib/Updater.php
@@ -1122,7 +1122,7 @@ EOF;
 	 * @throws LogException
 	 */
 	public function log($message) {
-		$updaterLogPath = $this->getUpdateDirectoryLocation() . '/updater.log';
+		$updaterLogPath = $this->getConfigOption('logfile_updater') ?? ($this->getUpdateDirectoryLocation() . '/updater.log');
 
 		$fh = fopen($updaterLogPath, 'a');
 		if ($fh === false) {


### PR DESCRIPTION
This PR allows the specification of a custom path to the updater log in the Nextcloud server config, e.g.:
```php
'logfile_updater' => '/var/log/nextcloud/updater.log',
```