### PR TITLE
Generate URLs via JavaScript

### DIFF
--- a/index.web.php
+++ b/index.web.php
@@ -255,10 +255,6 @@ if (isset($_POST['step'])) {
 
 $updater->log('[info] show HTML page');
 $updater->logVersion();
-$updaterUrl = explode('?', $_SERVER['REQUEST_URI'], 2)[0];
-if (strpos($updaterUrl, 'index.php') === false) {
-	$updaterUrl = rtrim($updaterUrl, '/') . '/index.php';
-}
 ?>
 
 <html>
@@ -545,7 +541,6 @@ if (strpos($updaterUrl, 'index.php') === false) {
 	<h1 class="header-appname">Updater</h1>
 </div>
 <input type="hidden" id="updater-access-key" value="<?php echo htmlentities($password) ?>"/>
-<input type="hidden" id="updater-endpoint" value="<?php echo htmlentities($updaterUrl) ?>"/>
 <input type="hidden" id="updater-step-start" value="<?php echo $stepNumber ?>" />
 <div id="content-wrapper">
 	<div id="content">
@@ -644,7 +639,7 @@ if (strpos($updaterUrl, 'index.php') === false) {
 				}?>">
 					<h2>Done</h2>
 					<div class="output hidden">
-						<a class="button" href="<?php echo htmlspecialchars(str_replace('/index.php', '/../', $updaterUrl), ENT_QUOTES); ?>">Go back to your Nextcloud instance to finish the update</a>
+						<a id="back-to-nextcloud" class="button">Go back to your Nextcloud instance to finish the update</a>
 					</div>
 				</li>
 			</ul>
@@ -675,6 +670,13 @@ if (strpos($updaterUrl, 'index.php') === false) {
 </body>
 <?php if ($auth->isAuthenticated()): ?>
 	<script>
+        var nextcloudUrl = window.location.href.replace('updater/', '').replace('index.php', '');
+
+        var backToButton = document.getElementById('back-to-nextcloud');
+        if (backToButton) {
+            backToButton.href = nextcloudUrl;
+        }
+
 		function escapeHTML(s) {
 			return s.toString().split('&').join('&amp;').split('<').join('&lt;').split('>').join('&gt;').split('"').join('&quot;').split('\'').join('&#039;');
 		}
@@ -742,7 +744,7 @@ if (strpos($updaterUrl, 'index.php') === false) {
 		function performStep(number, callback) {
 			started = true;
 			var httpRequest = new XMLHttpRequest();
-			httpRequest.open('POST', document.getElementById('updater-endpoint').value);
+			httpRequest.open('POST', window.location.href);
 			httpRequest.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
 			httpRequest.setRequestHeader('X-Updater-Auth', document.getElementById('updater-access-key').value);
 			httpRequest.onreadystatechange = function () {
@@ -983,7 +985,7 @@ if (strpos($updaterUrl, 'index.php') === false) {
 					el.classList.remove('hidden');
 
 					// above is the fallback if the Javascript redirect doesn't work
-					window.location.href = "<?php echo htmlspecialchars(str_replace('/index.php', '/../', $updaterUrl), ENT_QUOTES); ?>";
+					window.location.href = nextcloudUrl;
 				} else {
 					errorStep('step-done', 12);
 					var text = escapeHTML(response.response);


### PR DESCRIPTION
Fix #265, Close #312

URL generation via PHP do not consider cases where the application URL at a reverse proxy is different from the local URL.

Example:
- Public: home.acme/nextcloud
- Private: 192.168.1.8

A reverse proxy forwards the request internally. As the updater is not installed in a subdirectory, the generated (via PHP) URLs are wrong. nextcloud/server has all the code to generate proper URLs for such cases. However, this code is not available here.

Generating the URLs via JavaScript is simpler as the browser is already visiting the right page.

To configure nginx-proxy to serve an application from a subdirectory for testing:

      - VIRTUAL_HOST=server2.internal
      - VIRTUAL_PATH=/cloud/
      - VIRTUAL_DEST=/



