### PR TITLE
replace all rmdir by a recursive variant

### DIFF
--- a/index.php
+++ b/index.php
@@ -132,6 +132,26 @@ class Updater {
 	}
 
 	/**
+	 * Deletes a directory recursively
+	 */
+	private function rrmdir(string $src): void {
+	    $dir = opendir($src);
+	    while(false !== ( $file = readdir($dir)) ) {
+	        if (( $file != '.' ) && ( $file != '..' )) {
+	            $full = $src . '/' . $file;
+	            if ( is_dir($full) ) {
+	                rrmdir($full);
+	            }
+	            else {
+	                unlink($full);
+	            }
+	        }
+	    }
+	    closedir($dir);
+	    rmdir($src);
+	}
+
+	/**
 	 * Returns whether the web updater is disabled
 	 *
 	 * @return bool
@@ -844,10 +864,10 @@ EOF;
 			unlink($file);
 		}
 		foreach ($directories as $dir) {
-			rmdir($dir);
+			rrmdir($dir);
 		}
 
-		$state = rmdir($folder);
+		$state = rrmdir($folder);
 		if ($state === false) {
 			throw new \Exception('Could not rmdir ' . $folder);
 		}
@@ -953,7 +973,7 @@ EOF;
 					throw new \Exception('Could not unlink: '.$path);
 				}
 			} elseif ($fileInfo->isDir()) {
-				$state = rmdir($path);
+				$state = rrmdir($path);
 				if ($state === false) {
 					throw new \Exception('Could not rmdir: '.$path);
 				}
@@ -1007,7 +1027,7 @@ EOF;
 				}
 			}
 			if ($fileInfo->isDir()) {
-				$state = rmdir($path);
+				$state = rrmdir($path);
 				if ($state === false) {
 					throw new \Exception('Could not rmdir ' . $path);
 				}
@@ -1052,7 +1072,7 @@ EOF;
 		$storageLocation = $this->getUpdateDirectoryLocation() . '/updater-'.$this->getConfigOptionMandatoryString('instanceid') . '/downloads/nextcloud/';
 		$this->silentLog('[info] storage location: ' . $storageLocation);
 		$this->moveWithExclusions($storageLocation, []);
-		$state = rmdir($storageLocation);
+		$state = rrmdir($storageLocation);
 		if ($state === false) {
 			throw new \Exception('Could not rmdir $storagelocation');
 		}

--- a/lib/Updater.php
+++ b/lib/Updater.php
@@ -298,6 +298,27 @@ class Updater {
 	}
 
 	/**
+	 * Deletes a directory recursively
+	 */
+	private function rrmdir(string $src): void {
+		$dir = opendir($src);
+		while(false !== ( $file = readdir($dir)) ) {
+			if (( $file != '.' ) && ( $file != '..' )) {
+				$full = $src . '/' . $file;
+				if ( is_dir($full) ) {
+					rrmdir($full);
+				}
+				else {
+					unlink($full);
+				}
+			}
+		}
+		closedir($dir);
+		rmdir($src);
+	}
+	
+
+	/**
 	 * Checks for files that are unexpected.
 	 */
 	public function checkForExpectedFilesAndFolders(): void {
@@ -806,10 +827,10 @@ EOF;
 			unlink($file);
 		}
 		foreach ($directories as $dir) {
-			rmdir($dir);
+			rrmdir($dir);
 		}
 
-		$state = rmdir($folder);
+		$state = rrmdir($folder);
 		if ($state === false) {
 			throw new \Exception('Could not rmdir ' . $folder);
 		}
@@ -915,7 +936,7 @@ EOF;
 					throw new \Exception('Could not unlink: '.$path);
 				}
 			} elseif ($fileInfo->isDir()) {
-				$state = rmdir($path);
+				$state = rrmdir($path);
 				if ($state === false) {
 					throw new \Exception('Could not rmdir: '.$path);
 				}
@@ -969,7 +990,7 @@ EOF;
 				}
 			}
 			if ($fileInfo->isDir()) {
-				$state = rmdir($path);
+				$state = rrmdir($path);
 				if ($state === false) {
 					throw new \Exception('Could not rmdir ' . $path);
 				}
@@ -1014,7 +1035,7 @@ EOF;
 		$storageLocation = $this->getUpdateDirectoryLocation() . '/updater-'.$this->getConfigOptionMandatoryString('instanceid') . '/downloads/nextcloud/';
 		$this->silentLog('[info] storage location: ' . $storageLocation);
 		$this->moveWithExclusions($storageLocation, []);
-		$state = rmdir($storageLocation);
+		$state = rrmdir($storageLocation);
 		if ($state === false) {
 			throw new \Exception('Could not rmdir $storagelocation');
 		}


### PR DESCRIPTION
This PR tries to solve the failing updates due to issues on removing the old files.
See https://github.com/nextcloud/updater/issues/158 for details.

# Issue
Updater fails to delete old files:
![image](https://github.com/nextcloud/updater/assets/1783586/48004917-c272-4dc7-8233-a0e5f89acd79)

updater log on first deletion failure:
```
2023-10-23T00:06:59+0200 xGP6zzWOT0 [info] startStep("9")
2023-10-23T00:06:59+0200 xGP6zzWOT0 [info] deleteOldFiles()
2023-10-23T00:07:25+0200 xGP6zzWOT0 [info] config sample exists
2023-10-23T00:07:25+0200 xGP6zzWOT0 [info] themes README exists
2023-10-23T00:07:25+0200 xGP6zzWOT0 [error] POST request failed with other exception
2023-10-23T00:07:25+0200 xGP6zzWOT0 [error] Exception: Exception
Message: Could not rmdir: /home/xxx/www/nextcloud/updater/../lib/l10n
Code:0
Trace:
#0 /home/xxx/www/nextcloud/updater/index.php(1388): Updater->deleteOldFiles()
#1 {main}
File:/home/xxx/www/nextcloud/updater/index.php
Line:918
```

The general issue seems to be that [rmdir](https://www.php.net/manual/en/function.rmdir.php) only is able to delete empty folders.
The first time the issue occurs for me is on deleting the `lib/l10n` folder.
Looking on the folder, it clearly is not empty at that time:
```bash
> ls
af.json    az.js      br.js      el.js      es_AR.json es_EC.json es_PR.json fo.js      gd.json    hy.js      id.json    km.js      lb.js      mk.json    nl.json    pt_BR.js   si.js      th.js      vi.json
an.js      az.json    bs.js      el.json    es_CL.js   es_HN.json es_UY.json fo.json    he.js      hy.json    is.json    kn.js      lb.json    ms_MY.js   oc.js      pt_BR.json sk.js      th.json    zh_CN.js
ar.js      be.js      cs.json    eo.js      es_CL.json es_MX.json et_EE.json fr.js      hr.json    ia.js      it.js      kn.json    lo.json    nb.json    pl.js      pt_PT.js   sq.js      tk.json    zh_TW.js
ast.js     bg.json    da.js      eo.json    es_CO.js   es_NI.json eu.json    fr.json    hu.js      ia.json    ja.js      ko.js      lt_LT.json ne.json    pl.json    pt_PT.json sq.json    ur_PK.js
ast.json   bn_BD.js   de_DE.json es_419.js  es_DO.js   es_PE.js   fi.json    gd.js      hu.json    id.js      ka_GE.js   ko.json    lv.json    nl.js      ps.js      sc.json    ta.json    ur_PK.json
```
Note that it still contains 93 files. Odly, originally it contained 200 files, so some successed to get deleted...

# Fix
The linked PHP doc shows a snipped of of a recursive variant ([rrmdir](https://www.php.net/manual/en/function.rmdir.php#117354)) which recursively deletes all contained files/folders first.

Using that variant, I am successful to update Nextcloud `27.0.0` to the latest (currently `27.1.2`).