### PR TITLE
Fix move step

### DIFF
--- a/index.php
+++ b/index.php
@@ -1023,6 +1023,9 @@ EOF;
 					continue;
 				}
 			}
+
+			$this->recursiveDelete($path);
+		}
 	}
 
 	/**

--- a/index.php
+++ b/index.php
@@ -1010,20 +1010,16 @@ EOF;
 
 		// Cleanup (delete $path)
 		foreach ($this->getRecursiveDirectoryIterator($dataLocation) as $path => $fileInfo) {
-			$this->silentLog('[info]   ' . explode($dataLocation, $path)[1]);
-
 			$fileName = explode($dataLocation, $path)[1];
 			$folderStructure = explode('/', $fileName, -1);
 
 			// Exclude the exclusions
 			if (isset($folderStructure[0])) {
 				if (array_search($folderStructure[0], $excludedElements) !== false) {
-					$this->silentLog('[info]  skipped fileName: ' . $fileName);
 					continue;
 				}
 			} else {
 				if (array_search($fileName, $excludedElements) !== false) {
-					$this->silentLog('[info]  skipped fileName: ' . $fileName);
 					continue;
 				}
 			}

--- a/index.php
+++ b/index.php
@@ -995,24 +995,38 @@ EOF;
 						throw new \Exception('Could not mkdir ' . $this->baseDir  . '/../' . dirname($fileName));
 					}
 				}
-				$state = rename($path, $this->baseDir  . '/../' . $fileName);
+				$state = copy($path, $this->baseDir  . '/../' . $fileName);
 				if ($state === false) {
 					throw new \Exception(
 						sprintf(
-							'Could not rename %s to %s',
+							'Could not copy %s to %s',
 							$path,
 							$this->baseDir . '/../' . $fileName
 						)
 					);
 				}
 			}
-			if ($fileInfo->isDir()) {
-				$state = rmdir($path);
-				if ($state === false) {
-					throw new \Exception('Could not rmdir ' . $path);
+		}
+
+		// Cleanup (delete $path)
+		foreach ($this->getRecursiveDirectoryIterator($dataLocation) as $path => $fileInfo) {
+			$this->silentLog('[info]   ' . explode($dataLocation, $path)[1]);
+
+			$fileName = explode($dataLocation, $path)[1];
+			$folderStructure = explode('/', $fileName, -1);
+
+			// Exclude the exclusions
+			if (isset($folderStructure[0])) {
+				if (array_search($folderStructure[0], $excludedElements) !== false) {
+					$this->silentLog('[info]  skipped fileName: ' . $fileName);
+					continue;
+				}
+			} else {
+				if (array_search($fileName, $excludedElements) !== false) {
+					$this->silentLog('[info]  skipped fileName: ' . $fileName);
+					continue;
 				}
 			}
-		}
 	}
 
 	/**

--- a/lib/Updater.php
+++ b/lib/Updater.php
@@ -957,21 +957,32 @@ EOF;
 						throw new \Exception('Could not mkdir ' . $this->baseDir  . '/../' . dirname($fileName));
 					}
 				}
-				$state = rename($path, $this->baseDir  . '/../' . $fileName);
+				$state = copy($path, $this->baseDir  . '/../' . $fileName);
 				if ($state === false) {
 					throw new \Exception(
 						sprintf(
-							'Could not rename %s to %s',
+							'Could not copy %s to %s',
 							$path,
 							$this->baseDir . '/../' . $fileName
 						)
 					);
 				}
 			}
-			if ($fileInfo->isDir()) {
-				$state = rmdir($path);
-				if ($state === false) {
-					throw new \Exception('Could not rmdir ' . $path);
+		}
+
+		// Cleanup (delete $path)
+		foreach ($this->getRecursiveDirectoryIterator($dataLocation) as $path => $fileInfo) {
+			$fileName = explode($dataLocation, $path)[1];
+			$folderStructure = explode('/', $fileName, -1);
+
+			// Exclude the exclusions
+			if (isset($folderStructure[0])) {
+				if (array_search($folderStructure[0], $excludedElements) !== false) {
+					continue;
+				}
+			} else {
+				if (array_search($fileName, $excludedElements) !== false) {
+					continue;
 				}
 			}
 		}

--- a/lib/Updater.php
+++ b/lib/Updater.php
@@ -985,6 +985,8 @@ EOF;
 					continue;
 				}
 			}
+
+			$this->recursiveDelete($path);
 		}
 	}
 


### PR DESCRIPTION
The iterator gets gets messed up when modifying the directory. Thus we `copy()` instead of `rename()` and remove the whole folders/files afterwards in a separate iteration.

See https://github.com/nextcloud/updater/issues/509
This is a continuation of the fix https://github.com/nextcloud/updater/pull/510 for https://github.com/nextcloud/updater/issues/158