### PR TITLE
Update index.php to allow users to just copy paste the line on the co…

### DIFF
--- a/index.php
+++ b/index.php
@@ -1796,7 +1796,7 @@ $updater->logVersion();
 				<p>To login you need to provide the unhashed value of "updater.secret" in your config file.</p>
 				<p>If you don't know that value, you can access this updater directly via the Nextcloud admin screen or generate
 				your own secret:</p>
-				<code>php -r '$password = trim(shell_exec("openssl rand -base64 48"));if(strlen($password) === 64) {$hash = password_hash($password, PASSWORD_DEFAULT) . "\n"; echo "Insert as \"updater.secret\": ".$hash; echo "The plaintext value is: ".$password."\n";}else{echo "Could not execute OpenSSL.\n";};'</code>
+				<code>php -r '$password = trim(shell_exec("openssl rand -base64 48"));if(strlen($password) === 64) {$hash = password_hash($password, PASSWORD_DEFAULT); echo "Insert this line in your config.php: \n\n'"  'updater.secret' => '"'.$hash'"',\n\n"'"; echo "The plaintext value is: ".$password."\n";;}else{echo "Could not execute OpenSSL.\n";};'</code>
 				<form method="post" name="login">
 					<fieldset>
 						<input type="password" name="updater-secret-input" value=""


### PR DESCRIPTION
…nfig.php file

The initial syntax used double quotes and two points which is not the correct syntax in the config.php file instead of simple quote and "=>". This proposition to allow users to just copy paste the line into their config.php file