### PR TITLE
fix: silence rename warnings

### DIFF
--- a/lib/Updater.php
+++ b/lib/Updater.php
@@ -988,7 +988,7 @@ EOF;
 						throw new \Exception('Could not mkdir ' . $this->nextcloudDir . '/' . dirname($fileName));
 					}
 				}
-				$state = rename($path, $this->nextcloudDir . '/' . $fileName);
+				$state = @rename($path, $this->nextcloudDir . '/' . $fileName);
 				if ($state === false) {
 					throw new \Exception(
 						sprintf(


### PR DESCRIPTION
When the main Nextcloud and data folder are on separate devices, PHP will automatically fall back to copying and removing the source instead of renaming. However, it will print verbose warnings.

We should silence those warnings. An exception will be thrown if the rename actually fails.

### Example

```
PHP Warning:  rename(/srv/data/updater-ocfzgj3xa3i6/downloads/nextcloud/index.php,/var/www/nextcloud/updater/../index.php): Operation not permitted in phar:///var/www/nextcloud/updater/updater.phar/lib/Updater.php on line 972
```

However after all the errors did it report the move as successful.

```
[✔] Move new files in place
```