### PR TITLE
chore(ci): Remove PHP 8.1

### DIFF
--- a/.github/workflows/test-master.yml
+++ b/.github/workflows/test-master.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ["8.1", "8.2", "8.3"]
+        php-versions: ["8.2", "8.3"]
 
     name: test-master
 


### PR DESCRIPTION
PHP 8.1 is not supported on Master anymore. I quickly tried to add 8.4, but seems some dependencies need to updated for that..