### PR TITLE
chore: Add pre-commit hook to make sure to not push updater.phar with a dirty version

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-require_once __DIR__.'/vendor-bin/coding-standard/vendor/autoload.php';
+require_once __DIR__ . '/vendor-bin/coding-standard/vendor/autoload.php';
 
 use Nextcloud\CodingStandard\Config;
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+# SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.3.0
+  hooks:
+  - id: check-yaml
+  - id: check-added-large-files
+- repo: https://github.com/nextcloud/pre-commit-php.git
+  rev: 1.5.1
+  hooks:
+  - id: php-lint
+  - id: php-cs-fixer
+    files: \.(php)$
+    exclude: ^(vendor|vendor-bin)
+    args: []
+- repo: local
+  hooks:
+  - id: check-dirty-version
+    name: Check updater.phar for dirty version
+    entry: tests/checkPharForDirtyVersion.sh
+    language: script
+    files: ^updater.phar$

--- a/tests/checkPharForDirtyVersion.sh
+++ b/tests/checkPharForDirtyVersion.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
+#
+# SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
 
 grep --text "class Version {" -A3 updater.phar | grep -v dirty

--- a/tests/checkPharForDirtyVersion.sh
+++ b/tests/checkPharForDirtyVersion.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+grep --text "class Version {" -A3 updater.phar | grep -v dirty


### PR DESCRIPTION
When git status is not clean "dirty" gets added in lib/Version.php and
 that makes the check-same-code check to fail on updater.phar
This adds a pre-commit hook to detect that locally before pushing. Also added php-lint and cs-fixer hooks.